### PR TITLE
Adds goerli & lodestar configs

### DIFF
--- a/builds/serverless/main.go
+++ b/builds/serverless/main.go
@@ -396,7 +396,10 @@ var Cmd = &cobra.Command{
 					SecretKey: externalAwsAuth.SecretKey,
 				}
 				fmt.Println("INFO: verifying we can send validator messages to your lambda function")
-				serverless_aws_automation.VerifyLambdaSigner(ctx, lambdaAccessAuth, keystoresPath, externalAwsAuth.ServiceURL, ageEncryptionSecretName)
+				err := serverless_aws_automation.VerifyLambdaSigner(ctx, lambdaAccessAuth, keystoresPath, externalAwsAuth.ServiceURL, ageEncryptionSecretName)
+				if err != nil {
+					panic(err)
+				}
 			case "8", "createValidatorServiceRequestOnZeus":
 				fmt.Println("INFO: creating zeus validator service request")
 				if bearerToken == "" {
@@ -488,5 +491,4 @@ var Cmd = &cobra.Command{
 				}
 			}
 		}
-
 	}}

--- a/cookbooks/ethereum/beacons/beacon.go
+++ b/cookbooks/ethereum/beacons/beacon.go
@@ -32,7 +32,6 @@ var (
 		"serviceMonitorExecClient":      ExecClientMonitoringComponentBase,
 		"choreography":                  choreography_cookbooks.ChoreographyComponentBase,
 	}
-
 	ConsensusClientComponentBase = zeus_cluster_config_drivers.ComponentBaseDefinition{
 		SkeletonBases: map[string]zeus_cluster_config_drivers.ClusterSkeletonBaseDefinition{
 			"lighthouseHercules": ConsensusClientSkeletonBaseConfig,

--- a/cookbooks/ethereum/beacons/beacon_consensus_client_goerli.go
+++ b/cookbooks/ethereum/beacons/beacon_consensus_client_goerli.go
@@ -1,0 +1,93 @@
+package ethereum_beacon_cookbooks
+
+import (
+	"github.com/zeus-fyi/zeus/pkg/zeus/client/zeus_req_types"
+	zeus_cluster_config_drivers "github.com/zeus-fyi/zeus/pkg/zeus/cluster_config_drivers"
+	zeus_topology_config_drivers "github.com/zeus-fyi/zeus/pkg/zeus/workload_config_drivers"
+	v1Core "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+var lodestarRestPort = 9596
+
+var ConsensusClientGoerliSkeletonBaseConfig = zeus_cluster_config_drivers.ClusterSkeletonBaseDefinition{
+	SkeletonBaseChart:         zeus_req_types.TopologyCreateRequest{},
+	SkeletonBaseNameChartPath: BeaconConsensusClientChartPath,
+	TopologyConfigDriver: &zeus_topology_config_drivers.TopologyConfigDriver{
+		ConfigMapDriver: &zeus_topology_config_drivers.ConfigMapDriver{
+			ConfigMap: v1Core.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: "cm-consensus-client"},
+			},
+			SwapKeys: map[string]string{
+				"start.sh": LodestarGoerli + ".sh",
+			},
+		},
+		ServiceDriver: &zeus_topology_config_drivers.ServiceDriver{
+			Service: v1Core.Service{
+				Spec: v1Core.ServiceSpec{
+					Ports: []v1Core.ServicePort{
+						{
+							Name:       "hercules",
+							Protocol:   "TCP",
+							Port:       9003,
+							TargetPort: intstr.IntOrString{Type: intstr.String, StrVal: "hercules"},
+						},
+						{
+							Name:       "p2p-tcp",
+							Protocol:   "TCP",
+							Port:       9000,
+							TargetPort: intstr.IntOrString{Type: intstr.String, StrVal: "p2p-tcp"},
+						},
+						{
+							Name:       "p2p-udp",
+							Protocol:   "UDP",
+							Port:       9000,
+							TargetPort: intstr.IntOrString{Type: intstr.String, StrVal: "p2p-udp"},
+						},
+						{
+							Name:       "http-api",
+							Protocol:   "TCP",
+							Port:       int32(lodestarRestPort),
+							TargetPort: intstr.IntOrString{Type: intstr.String, StrVal: "http-api"},
+						},
+					},
+				},
+			},
+		},
+		StatefulSetDriver: &zeus_topology_config_drivers.StatefulSetDriver{
+			ContainerDrivers: map[string]zeus_topology_config_drivers.ContainerDriver{
+				consensusClient: {Container: v1Core.Container{
+					Name:  consensusClient,
+					Image: lodestarDockerImage,
+					Ports: []v1Core.ContainerPort{
+						{
+							Name:          "p2p-tcp",
+							ContainerPort: 9000,
+							Protocol:      "TCP",
+						},
+						{
+							Name:          "p2p-udp",
+							ContainerPort: 9000,
+							Protocol:      "UDP",
+						},
+						{
+							Name:          "http-api",
+							ContainerPort: int32(lodestarRestPort),
+							Protocol:      "TCP",
+						},
+					},
+				}},
+			},
+			PVCDriver: &zeus_topology_config_drivers.PersistentVolumeClaimsConfigDriver{
+				PersistentVolumeClaimDrivers: map[string]v1Core.PersistentVolumeClaim{
+					consensusStorageDiskName: {
+						ObjectMeta: metav1.ObjectMeta{Name: consensusStorageDiskName},
+						Spec: v1Core.PersistentVolumeClaimSpec{Resources: v1Core.ResourceRequirements{
+							Requests: v1Core.ResourceList{"storage": resource.MustParse(consensusStorageDiskSizeGoerli)},
+						}},
+					},
+				}},
+		},
+	}}

--- a/cookbooks/ethereum/beacons/beacon_consensus_config_driver.go
+++ b/cookbooks/ethereum/beacons/beacon_consensus_config_driver.go
@@ -11,12 +11,16 @@ const (
 	consensusClient                   = "zeus-consensus-client"
 	consensusStorageDiskName          = "consensus-client-storage"
 	consensusStorageDiskSizeEphemeral = "2Gi"
+	consensusStorageDiskSizeGoerli    = "100Gi"
 
 	LighthouseEphemeral         = "lighthouseEphemeral"
 	downloadLighthouseEphemeral = "downloadLighthouseEphemeral"
 
 	lighthouseDockerImage        = "sigp/lighthouse:v3.3.0-modern"
 	lighthouseDockerImageCapella = "sigp/lighthouse:capella"
+
+	LodestarGoerli      = "lodestarGoerli"
+	lodestarDockerImage = "chainsafe/lodestar:v1.5.1"
 )
 
 func EphemeralConsensusClientLighthouseConfig(inf topology_workloads.TopologyBaseInfraWorkload) {

--- a/cookbooks/ethereum/beacons/beacon_exec_client_config_driver.go
+++ b/cookbooks/ethereum/beacons/beacon_exec_client_config_driver.go
@@ -11,12 +11,15 @@ const (
 	execClient                  = "zeus-exec-client"
 	execClientDiskName          = "exec-client-storage"
 	execClientDiskSizeEphemeral = "10Gi"
+	execClientDiskSizeGoerli    = "500Gi"
 
-	hercules              = "hercules"
-	herculesEphemeral     = "herculesEphemeral"
-	GethEphemeral         = "gethEphemeral"
+	hercules          = "hercules"
+	herculesEphemeral = "herculesEphemeral"
+	GethEphemeral     = "gethEphemeral"
+	GethGoerli        = "gethGoerli"
+
 	downloadGethEphemeral = "downloadGethEphemeral"
-	gethDockerImage       = "ethereum/client-go:v1.10.26"
+	gethDockerImage       = "ethereum/client-go:v1.11.4"
 
 	gethDockerImageCapella = "ethpandaops/geth:master"
 )

--- a/cookbooks/ethereum/beacons/beacon_exec_client_goerli.go
+++ b/cookbooks/ethereum/beacons/beacon_exec_client_goerli.go
@@ -1,0 +1,43 @@
+package ethereum_beacon_cookbooks
+
+import (
+	"github.com/zeus-fyi/zeus/pkg/zeus/client/zeus_req_types"
+	zeus_cluster_config_drivers "github.com/zeus-fyi/zeus/pkg/zeus/cluster_config_drivers"
+	zeus_topology_config_drivers "github.com/zeus-fyi/zeus/pkg/zeus/workload_config_drivers"
+	v1Core "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var ExecClientGoerliSkeletonBaseConfig = zeus_cluster_config_drivers.ClusterSkeletonBaseDefinition{
+	SkeletonBaseChart:         zeus_req_types.TopologyCreateRequest{},
+	SkeletonBaseNameChartPath: BeaconExecClientChartPath,
+	TopologyConfigDriver: &zeus_topology_config_drivers.TopologyConfigDriver{
+		ConfigMapDriver: &zeus_topology_config_drivers.ConfigMapDriver{
+			ConfigMap: v1Core.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: "cm-exec-client"},
+			},
+			SwapKeys: map[string]string{
+				"start.sh": GethGoerli + ".sh",
+			},
+		},
+		StatefulSetDriver: &zeus_topology_config_drivers.StatefulSetDriver{
+			ContainerDrivers: map[string]zeus_topology_config_drivers.ContainerDriver{
+				execClient: {
+					Container: v1Core.Container{
+						Name:  execClient,
+						Image: gethDockerImage,
+					},
+				},
+			},
+			PVCDriver: &zeus_topology_config_drivers.PersistentVolumeClaimsConfigDriver{
+				PersistentVolumeClaimDrivers: map[string]v1Core.PersistentVolumeClaim{
+					execClientDiskName: {
+						ObjectMeta: metav1.ObjectMeta{Name: execClientDiskName},
+						Spec: v1Core.PersistentVolumeClaimSpec{Resources: v1Core.ResourceRequirements{
+							Requests: v1Core.ResourceList{"storage": resource.MustParse(execClientDiskSizeGoerli)},
+						}},
+					},
+				}},
+		},
+	}}

--- a/cookbooks/ethereum/beacons/beacon_goerli.go
+++ b/cookbooks/ethereum/beacons/beacon_goerli.go
@@ -1,0 +1,35 @@
+package ethereum_beacon_cookbooks
+
+import (
+	"github.com/zeus-fyi/zeus/pkg/zeus/client/zeus_common_types"
+	zeus_cluster_config_drivers "github.com/zeus-fyi/zeus/pkg/zeus/cluster_config_drivers"
+)
+
+var (
+	BeaconGoerliClusterDefinition = zeus_cluster_config_drivers.ClusterDefinition{
+		ClusterClassName: "ethereumGoerliBeacons",
+		CloudCtxNs:       BeaconGoerliCloudCtxNs,
+		ComponentBases:   BeaconGoerliComponentBases,
+	}
+	BeaconGoerliCloudCtxNs = zeus_common_types.CloudCtxNs{
+		CloudProvider: "do",
+		Region:        "sfo3",
+		Context:       "do-sfo3-dev-do-sfo3-zeus",
+		Namespace:     "goerli-beacon", // set with your own namespace
+		Env:           "production",
+	}
+	BeaconGoerliComponentBases = map[string]zeus_cluster_config_drivers.ComponentBaseDefinition{
+		"consensusClients": ConsensusClientGoerliComponentBase,
+		"execClients":      ExecClientGoerliComponentBase,
+	}
+	ConsensusClientGoerliComponentBase = zeus_cluster_config_drivers.ComponentBaseDefinition{
+		SkeletonBases: map[string]zeus_cluster_config_drivers.ClusterSkeletonBaseDefinition{
+			"lodestarHercules": ConsensusClientGoerliSkeletonBaseConfig,
+		},
+	}
+	ExecClientGoerliComponentBase = zeus_cluster_config_drivers.ComponentBaseDefinition{
+		SkeletonBases: map[string]zeus_cluster_config_drivers.ClusterSkeletonBaseDefinition{
+			"gethHercules": ExecClientGoerliSkeletonBaseConfig,
+		},
+	}
+)

--- a/cookbooks/ethereum/beacons/beacon_goerli_test.go
+++ b/cookbooks/ethereum/beacons/beacon_goerli_test.go
@@ -1,0 +1,41 @@
+package ethereum_beacon_cookbooks
+
+import (
+	"context"
+	"fmt"
+)
+
+func (t *BeaconCookbookTestSuite) TestGoerliClusterDeployV2() {
+	cd := BeaconGoerliClusterDefinition
+	_, err := cd.UploadChartsFromClusterDefinition(ctx, t.ZeusTestClient, true)
+	t.Require().Nil(err)
+
+	cdep := cd.GenerateDeploymentRequest()
+	_, err = t.ZeusTestClient.DeployCluster(ctx, cdep)
+	t.Require().Nil(err)
+}
+
+func (t *BeaconCookbookTestSuite) TestGoerliClusterSetupV2() {
+	cd := BeaconGoerliClusterDefinition
+	gcd := cd.BuildClusterDefinitions()
+	t.Assert().NotEmpty(gcd)
+	fmt.Println(gcd)
+
+	gdr := cd.GenerateDeploymentRequest()
+	t.Assert().NotEmpty(gdr)
+	fmt.Println(gdr)
+
+	sbDefs, err := cd.GenerateSkeletonBaseCharts()
+	t.Require().Nil(err)
+	t.Assert().NotEmpty(sbDefs)
+}
+
+func (t *BeaconCookbookTestSuite) TestGoerliClusterDefinitionCreationV2() {
+	cd := BeaconGoerliClusterDefinition
+	gcd := cd.BuildClusterDefinitions()
+	t.Assert().NotEmpty(gcd)
+	fmt.Println(gcd)
+
+	err := gcd.CreateClusterClassDefinitions(context.Background(), t.ZeusTestClient)
+	t.Require().Nil(err)
+}

--- a/cookbooks/ethereum/beacons/beacon_goerli_test.go
+++ b/cookbooks/ethereum/beacons/beacon_goerli_test.go
@@ -15,6 +15,14 @@ func (t *BeaconCookbookTestSuite) TestGoerliClusterDeployV2() {
 	t.Require().Nil(err)
 }
 
+func (t *BeaconCookbookTestSuite) TestGoerliClusterDestroy() {
+	knsReq := DeployConsensusClientKnsReq
+	knsReq.CloudCtxNs = BeaconGoerliClusterDefinition.CloudCtxNs
+	resp, err := t.ZeusTestClient.DestroyDeploy(ctx, knsReq)
+	t.Require().Nil(err)
+	t.Assert().NotEmpty(resp)
+}
+
 func (t *BeaconCookbookTestSuite) TestGoerliClusterSetupV2() {
 	cd := BeaconGoerliClusterDefinition
 	gcd := cd.BuildClusterDefinitions()

--- a/cookbooks/ethereum/beacons/infra/consensus_client/cm-consensus-client.yaml
+++ b/cookbooks/ethereum/beacons/infra/consensus_client/cm-consensus-client.yaml
@@ -27,6 +27,20 @@ data:
   pause.sh: |-
     #!/bin/sh
     exec sleep 100000000000000000
+  lodestarGoerli.sh: |-
+    #!/bin/sh
+    exec node /usr/app/node_modules/.bin/lodestar beacon \
+              --dataDir /data \
+              --network goerli \
+              --rest \
+              --execution.urls http://zeus-exec-client:8551 \
+              --rest.address 0.0.0.0 \
+              --rest.namespace '*' \
+              --rest.port 9596 \
+              --metrics --logFile /logs/beacon.log \
+              --logFileLevel debug \
+              --logFileDailyRotate 5 \
+              --jwt-secret /data/jwt.hex
   lighthouse.sh: |-
     #!/bin/sh
     exec lighthouse beacon_node \

--- a/cookbooks/ethereum/beacons/infra/exec_client/cm-exec-client.yaml
+++ b/cookbooks/ethereum/beacons/infra/exec_client/cm-exec-client.yaml
@@ -54,6 +54,28 @@ data:
       --authrpc.addr=0.0.0.0 \
       --authrpc.port=8551 \
       --authrpc.vhosts=*
+  gethGoerli.sh: |-
+    #!/bin/sh
+    exec geth \
+      --datadir=/data \
+      --port=30303 \
+      --goerli \
+      --http \
+      --http.addr=0.0.0.0 \
+      --http.port=8545 \
+      --http.vhosts=* \
+      --http.corsdomain=* \
+      --ws \
+      --ws.addr=0.0.0.0 \
+      --ws.port=8546 \
+      --ws.origins=* \
+      --metrics \
+      --metrics.addr=0.0.0.0 \
+      --metrics.port=6060 \
+      --authrpc.jwtsecret=/data/jwt.hex \
+      --authrpc.addr=0.0.0.0 \
+      --authrpc.port=8551 \
+      --authrpc.vhosts=*
   hercules.sh: |-
     #!/bin/sh 
     hercules

--- a/pkg/zeus/workload_config_drivers/services.go
+++ b/pkg/zeus/workload_config_drivers/services.go
@@ -6,12 +6,16 @@ import (
 )
 
 type ServiceDriver struct {
+	v1.Service
 	ExtendPorts []v1.ServicePort
 }
 
 func (s *ServiceDriver) SetServiceConfigs(svc *v1.Service) {
 	if svc == nil {
 		return
+	}
+	if s.Service.Spec.Ports != nil {
+		svc.Spec.Ports = s.Service.Spec.Ports
 	}
 	if s.ExtendPorts != nil {
 		if svc.Spec.Ports == nil {


### PR DESCRIPTION
adds lodestar (consensus client addition) & Goerli configs,

0->1 hour deployed syncing beacon compatible on enterprise level k8s (unrelated previous commits)

- beacon cluster definition expanded. 
- supports a network entirely

no verifications other than checking beacon successfully syncs, likely to be better tuning for p2p setting for lodestar 

https://github.com/zeus-fyi/zeus/pull/105/commits/09003e729609c3bdbbd94561fc54e128274a6dd5

![Screenshot 2023-03-10 at 12 25 34 PM](https://user-images.githubusercontent.com/17446735/224423743-31d9fb1f-5bc9-4d15-9275-f3a5991ab427.png)


![Screenshot 2023-03-10 at 12 25 18 PM](https://user-images.githubusercontent.com/17446735/224423684-3da77f96-2031-4ae9-ab8d-d53f8a13b5e4.png)

![Screenshot 2023-03-10 at 12 36 03 PM](https://user-images.githubusercontent.com/17446735/224423771-3524dfc6-7c7f-4b20-b770-895f67ff26d1.png)


